### PR TITLE
Do not add to package-list packages that have been excluded by 'excludePackageNames' (closes #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ As a result, the build log was outputting many errors of the form:
 The build seemed to be only generating the `element-list` file.
 
 To resolve the issue with javadoc links, and remove the errors from the logs, this plugin can be used to generate the `package-list`
-file dynamically based on a scan of the source directories of submodules.
+file dynamically based on a scan of the source directories of submodules. Packages that were excluded by a
+[`excludePackageNames`](https://maven.apache.org/plugins/maven-javadoc-plugin/javadoc-mojo.html#excludePackageNames) in the
+`maven-javadoc-plugin` configuration are not included in the file.
 
 The plugin should be bound to the `package` phase, and included as follows:
 

--- a/src/main/java/com/networknt/javadoc/plugin/packagelist/GenPackageList.java
+++ b/src/main/java/com/networknt/javadoc/plugin/packagelist/GenPackageList.java
@@ -2,6 +2,9 @@ package com.networknt.javadoc.plugin.packagelist;
 
 import com.thoughtworks.qdox.JavaProjectBuilder;
 import com.thoughtworks.qdox.model.JavaPackage;
+
+import org.apache.maven.model.Build;
+import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -9,11 +12,16 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
 
 import java.io.*;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 @Mojo(name="gen-package-list")
 public class GenPackageList extends AbstractMojo {
@@ -25,6 +33,14 @@ public class GenPackageList extends AbstractMojo {
         String sourceDir = mavenProject.getModel().getBuild().getSourceDirectory();
         String targetDir = mavenProject.getModel().getBuild().getDirectory();
         if (mavenProject.getModel().getParent() != null) {
+            List<Pattern> excludeREList;
+            try {
+                excludeREList = getExcludedRegExpList();
+            } catch (Exception e) {
+                excludeREList = null;
+                getLog().warn(
+                        "Could not obtain the configuration for excluded packages from the maven-javadoc-plugin.");
+            }
             try {
                 JavaProjectBuilder javaProjectBuilder = new JavaProjectBuilder();
                 javaProjectBuilder.addSourceTree(new File(sourceDir));
@@ -32,7 +48,11 @@ public class GenPackageList extends AbstractMojo {
                 if (packages != null && packages.size() > 0) {
                     List<String> packageNames = new ArrayList<>();
                     for (JavaPackage javaPackage : packages) {
-                        packageNames.add(javaPackage.getName());
+                        String pkgName = javaPackage.getName();
+                        if (excludeREList != null && excludeMatch(excludeREList, pkgName)) {
+                            continue;
+                        }
+                        packageNames.add(pkgName);
                     }
                     new File(targetDir.concat("/apidocs")).mkdirs();
                     FileUtils.fileWrite(targetDir.concat("/apidocs/package-list"), String.join("\n", packageNames));
@@ -45,4 +65,91 @@ public class GenPackageList extends AbstractMojo {
             }
         }
     }
+
+    /**
+     * Obtains a list of excluded regexp patterns from the
+     * {@code excludePackageNames} configuration of the
+     * {@code maven-javadoc-plugin}.
+     * 
+     * @return the list of excluded regexp patterns, or {@code null} if there are no
+     *         excluded packages.
+     */
+    private List<Pattern> getExcludedRegExpList() {
+        List<Pattern> excludeREList = null;
+        Build build = mavenProject.getModel().getBuild();
+        List<Plugin> plugins;
+        if (build != null && (plugins = build.getPlugins()) != null) {
+            for (Plugin plugin : plugins) {
+                String groupId = plugin.getGroupId();
+                String artifactId = plugin.getArtifactId();
+                if ("org.apache.maven.plugins".equals(groupId) && "maven-javadoc-plugin".equals(artifactId)) {
+                    Xpp3Dom configDom = (Xpp3Dom) plugin.getConfiguration();
+                    Xpp3Dom epnDom = configDom.getChild("excludePackageNames");
+                    if (epnDom != null) {
+                        String excludePackageNames = epnDom.getValue();
+                        if (excludePackageNames != null) {
+                            List<String> excludedList = Arrays.asList(excludePackageNames.split("[,:;]"));
+                            for (String excludeStr : excludedList) {
+                                String reStr = convertExcludeToRegExp(excludeStr);
+                                try {
+                                    Pattern excludeRE = Pattern.compile(reStr);
+                                    if (excludeREList == null) {
+                                        excludeREList = new ArrayList<Pattern>();
+                                    }
+                                    excludeREList.add(excludeRE);
+                                } catch (PatternSyntaxException e) {
+                                    getLog().warn("Unable to process exclusion " + excludeStr + '.');
+                                }
+                            }
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+        return excludeREList;
+    }
+
+    /**
+     * Attempts to convert a package exclusion expression to a <i>regexp</i>.
+     * <p>
+     * It may not be fully compatible with the <a href=
+     * "https://maven.apache.org/plugins/maven-javadoc-plugin/javadoc-mojo.html#excludePackageNames">behavior
+     * of <code>excludePackageNames</code></a>.
+     * </p>
+     * 
+     * @param excludeStr the excluded package expression from
+     *                   {@code excludePackageNames}.
+     * @return a string containing a compatible <i>regexp</i>.
+     */
+    private String convertExcludeToRegExp(String excludeStr) {
+        if (excludeStr.charAt(0) == '*') {
+            if (excludeStr.length() > 1) {
+                excludeStr = excludeStr.substring(1);
+            } else {
+                return ".*";
+            }
+        } else {
+            excludeStr = '^' + excludeStr;
+        }
+        excludeStr = excludeStr.replace(".", "\\.");
+        int elen = excludeStr.length();
+        if (excludeStr.charAt(elen - 1) == '*') {
+            excludeStr = excludeStr.subSequence(0, elen) + ".*";
+        } else {
+            excludeStr = excludeStr + "\\.?.*";
+        }
+        return excludeStr;
+    }
+
+    private boolean excludeMatch(List<Pattern> excludeREList, String pkgName) {
+        for (Pattern excludeRE : excludeREList) {
+            Matcher matcher = excludeRE.matcher(pkgName);
+            if (matcher.matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 }


### PR DESCRIPTION
This is my solution to issue #3. The potentially problematic part is the `convertExcludeToRegExp(String)` method, which attempts to convert a package exclusion into a regular expression, more or less according to the [documented behavior of `excludePackageNames`]( https://maven.apache.org/plugins/maven-javadoc-plugin/javadoc-mojo.html#excludePackageNames). The caveat is that I have seen claims that the actual behavior of the `maven-javadoc-plugin` with the wildcards is not what is documented, and I haven't took the time to investigate how that plugin really deals with wildcards.

So I guess that at some point things could get screwed for some particular case(s), but this patch works for me and is better than nothing.